### PR TITLE
equip gearset when setting tp mode 

### DIFF
--- a/Ninja.lua
+++ b/Ninja.lua
@@ -29,6 +29,15 @@ end
 gearswap_box_config = {pos={x=20,y=240},padding=8,text={font='sans-serif',size=10,stroke={width=2,alpha=255},Fonts={'sans-serif'},},bg={alpha=0},flags={}}
 gearswap_jobbox = texts.new(gearswap_box_config)
 
+
+function equip_selected_set()
+	set = sets.aftercast
+	if set[tp_mode] then
+		set = set[tp_mode]
+	end
+	equip(set)
+end
+
 function user_setup()
 	check_tool_count()
 	gearswap_jobbox:text(gearswap_box())		
@@ -37,12 +46,13 @@ end
 
 
 function self_command(command)
-	 local args = split_args(command)
-		if args[1] == 'tp' then
+	local args = split_args(command)
+	if args[1] == 'tp' then
 		tp_mode = args[2]
-	 elseif args[1] == 'mb' then
-		mb_mode = args[2]
-	 end
+		equip_selected_set()
+		gearswap_jobbox:text(gearswap_box())
+		gearswap_jobbox:show()
+	end
 end
  
 function split_args(args)

--- a/Ninja.lua
+++ b/Ninja.lua
@@ -38,10 +38,14 @@ function equip_selected_set()
 	equip(set)
 end
 
-function user_setup()
-	check_tool_count()
+function updateUI()
 	gearswap_jobbox:text(gearswap_box())		
 	gearswap_jobbox:show()
+end
+
+function user_setup()
+	check_tool_count()
+	updateUI()
 end
 
 
@@ -50,8 +54,11 @@ function self_command(command)
 	if args[1] == 'tp' then
 		tp_mode = args[2]
 		equip_selected_set()
-		gearswap_jobbox:text(gearswap_box())
-		gearswap_jobbox:show()
+		updateUI()
+	elseif args[1] == 'mb' then
+		mb_mode = args[2]
+		equip_selected_set()
+		updateUI()
 	end
 end
  

--- a/Ninja.lua
+++ b/Ninja.lua
@@ -498,6 +498,13 @@ function get_sets()
 	
 end
 
+
+function equipSetConditionally(proposedSet)
+	if tp_mode ~= 'hp' then
+		equip(proposedSet)
+	end
+end
+
 -----------------------------------------------------------------------------------
 -- This is the precast section.  It is used for things you want to happen before you start to start to use the ability or spell.
  function precast(spell)
@@ -528,95 +535,95 @@ end
 	end
 
 	if spell.english:startswith('Utsusemi') then
-		equip(sets.precast.utsusemi)
+		equipSetConditionally(sets.precast.utsusemi)
 	end
 
 	if spell.english:startswith('Monomi') then
-		equip(sets.precast.fc)
+		equipSetConditionally(sets.precast.fc)
 	end
 
 	if spell.english:startswith('Tonko') then
-		equip(sets.precast.fc)
+		equipSetConditionally(sets.precast.fc)
 	end
 	
 	if spell.english:startswith('Gekka') then
-		equip(sets.precast.fc)
+		equipSetConditionally(sets.precast.fc)
 	end
 
 	if spell.english:startswith('Yain') then
-		equip(sets.precast.fc)
+		equipSetConditionally(sets.precast.fc)
 	end
 	
 	if spell.english:startswith('Kakka') then
-		equip(sets.precast.fc)
+		equipSetConditionally(sets.precast.fc)
 	end
 
 	if spell.english:startswith('Myoshu') then
-		equip(sets.precast.fc)
+		equipSetConditionally(sets.precast.fc)
 	end
 
 	if spell.english:startswith('Migawari') then
-		equip(sets.precast.fc)
+		equipSetConditionally(sets.precast.fc)
 	end
 	
 	if spell.english:startswith('Yurin') then
-		equip(sets.precast.fc)
+		equipSetConditionally(sets.precast.fc)
 	end
 	
 	if spell.english:startswith('Dokumori') then
-		equip(sets.precast.fc)
+		equipSetConditionally(sets.precast.fc)
 	end
 
 	if spell.english:startswith('Aisha') then
-		equip(sets.precast.fc)
+		equipSetConditionally(sets.precast.fc)
 	end
 
 	if spell.english:startswith('Kurayami') then
-		equip(sets.precast.fc)
+		equipSetConditionally(sets.precast.fc)
 	end
 	
 	if spell.english:startswith('Hojo') then
-		equip(sets.precast.fc)
+		equipSetConditionally(sets.precast.fc)
 	end
 
 	if spell.english:startswith('Jubaku') then
-		equip(sets.precast.fc)
+		equipSetConditionally(sets.precast.fc)
 	end
 
 	if spell.english:startswith('Katon') then
-		equip(sets.precast.fc)
+		equipSetConditionally(sets.precast.fc)
 	end
 
 	if spell.english:startswith('Hyoton') then
-		equip(sets.precast.fc)
+		equipSetConditionally(sets.precast.fc)
 	end
 	
 	if spell.english:startswith('Huton') then
-		equip(sets.precast.fc)
+		equipSetConditionally(sets.precast.fc)
 	end
 
 	if spell.english:startswith('Doton') then
-		equip(sets.precast.fc)
+		equipSetConditionally(sets.precast.fc)
 	end
 
 	if spell.english:startswith('Raiton') then
-		equip(sets.precast.fc)
+		equipSetConditionally(sets.precast.fc)
 	end
 	
 	if spell.english:startswith('Suiton') then
-		equip(sets.precast.fc)
+		equipSetConditionally(sets.precast.fc)
 	end
 	
 	if spell.type == "WhiteMagic" then
-		equip(sets.precast.fc)
+		equipSetConditionally(sets.precast.fc)
 	end
 
 	if spell.type == "BlackMagic" then
-		equip(sets.precast.fc)
+		equipSetConditionally(sets.precast.fc)
 	end
 
 	if spell.type == "Trust" then
-		equip(sets.precast.fc)
+		equipSetConditionally(sets.precast.fc)
 	end
 end
 
@@ -625,63 +632,63 @@ end
 function midcast(spell, act)
 
 	if spell.english:startswith('Utsusemi') then
-		equip(sets.precast.utsusemi)
+		equipSetConditionally(sets.precast.utsusemi)
 	end
 
 	if spell.english == "Provoke" then
-		equip(sets.midcast.enmity)
+		equipSetConditionally(sets.midcast.enmity)
 	end
 
 	if spell.english == "Warcry" then
-		equip(sets.midcast.enmity)
+		equipSetConditionally(sets.midcast.enmity)
 	end
 
 	if spell.english == "Animated Flourish" then
-		equip(sets.midcast.enmity)
+		equipSetConditionally(sets.midcast.enmity)
 	end
 
 	if spell.english == "Violent Flourish" then
-		equip(sets.midcast.enfnin)
+		equipSetConditionally(sets.midcast.enfnin)
 	end
 
 	if spell.english:startswith('Curing') then
-		equip(sets.midcast.waltz)
+		equipSetConditionally(sets.midcast.waltz)
 	end
 
 	if spell.english == "Divine Waltz" then
-		equip(sets.midcast.waltz)
+		equipSetConditionally(sets.midcast.waltz)
 	end
 	
 	if spell.english:startswith('Migawari') then
-		equip(sets.midcast.migawari)
+		equipSetConditionally(sets.midcast.migawari)
 	end
 	
 	if spell.english:startswith('Kurayami') then
-		equip(sets.midcast.enfnin)
+		equipSetConditionally(sets.midcast.enfnin)
 	end
 
 	if spell.english:startswith('Hojo') then
-		equip(sets.midcast.enfnin)
+		equipSetConditionally(sets.midcast.enfnin)
 	end
 
 	if spell.english:startswith('Jubaku') then
-		equip(sets.midcast.enfnin)
+		equipSetConditionally(sets.midcast.enfnin)
 	end
 
 	if spell.english:startswith('Aisha') then
-		equip(sets.midcast.enfnin)
+		equipSetConditionally(sets.midcast.enfnin)
 	end
 
 	if spell.english:startswith('Yurin') then
-		equip(sets.midcast.enfnin)
+		equipSetConditionally(sets.midcast.enfnin)
 	end
 
 	if spell.type == "WhiteMagic" then
-		equip(sets.midcast.enfnin)
+		equipSetConditionally(sets.midcast.enfnin)
 	end
 
 	if spell.type == "BlackMagic" then
-		equip(sets.midcast.enfnin)
+		equipSetConditionally(sets.midcast.enfnin)
 	end
 
 	if spell.english:startswith('Katon') then
@@ -689,7 +696,7 @@ function midcast(spell, act)
 		if set[mb_mode] then
 			set = set[mb_mode]
 		end
-		equip(set)
+		equipSetConditionally(set)
 	end
 
 	if spell.english:startswith('Hyoton') then
@@ -697,7 +704,7 @@ function midcast(spell, act)
 		if set[mb_mode] then
 			set = set[mb_mode]
 		end
-		equip(set)
+		equipSetConditionally(set)
 	end
 
 	if spell.english:startswith('Huton') then
@@ -705,7 +712,7 @@ function midcast(spell, act)
 		if set[mb_mode] then
 			set = set[mb_mode]
 		end
-		equip(set)
+		equipSetConditionally(set)
 	end
 
 	if spell.english:startswith('Doton') then
@@ -713,7 +720,7 @@ function midcast(spell, act)
 		if set[mb_mode] then
 			set = set[mb_mode]
 		end
-		equip(set)
+		equipSetConditionally(set)
 	end
 
 	if spell.english:startswith('Raiton') then
@@ -721,7 +728,7 @@ function midcast(spell, act)
 		if set[mb_mode] then
 			set = set[mb_mode]
 		end
-		equip(set)
+		equipSetConditionally(set)
 	end
 
 	if spell.english:startswith('Suiton')then
@@ -729,111 +736,111 @@ function midcast(spell, act)
 		if set[mb_mode] then
 			set = set[mb_mode]
 		end
-		equip(set)
+		equipSetConditionally(set)
 	end
 	
 	if spell.english == "Blade: Hi" then
-		equip(sets.midcast.bladehi)
+		equipSetConditionally(sets.midcast.bladehi)
 	end
 
 	if spell.english == "Blade: Metsu" then
-		equip (sets.midcast.blademetsu)
+		equipSetConditionally (sets.midcast.blademetsu)
 	end
 
 	if spell.english == "Blade: Shun" then
-		equip (sets.midcast.bladeshun)
+		equipSetConditionally (sets.midcast.bladeshun)
 	end
 
 	if spell.english == "Blade: Ten" then
-		equip (sets.midcast.bladeten)
+		equipSetConditionally (sets.midcast.bladeten)
 	end
 	
 	if spell.english == "Blade: Chi" then
-		equip (sets.midcast.bladechi)
+		equipSetConditionally (sets.midcast.bladechi)
 	end
 	
 	if spell.english == "Blade: To" then
-		equip (sets.midcast.bladechi)
+		equipSetConditionally (sets.midcast.bladechi)
 	end
 	
 	if spell.english == "Blade: Yu" then
-		equip (sets.midcast.bladechi)
+		equipSetConditionally (sets.midcast.bladechi)
 	end
 
 	if spell.english == "Blade: Kamu" then
-		equip (sets.midcast.bladechi)
+		equipSetConditionally (sets.midcast.bladechi)
 	end
 
 	if spell.english == "Blade: Ku" then
-		equip (sets.midcast.bladeku)
+		equipSetConditionally (sets.midcast.bladeku)
 	end
 
 	if spell.english == "Blade: Teki" then
-		equip (sets.midcast.bladechi)
+		equipSetConditionally (sets.midcast.bladechi)
 	end
 
 	if spell.english == "Blade: Retsu" then
-		equip (sets.midcast.bladeten)
+		equipSetConditionally (sets.midcast.bladeten)
 	end
 
 	if spell.english == "Blade: Rin" then
-		equip (sets.midcast.bladeten)
+		equipSetConditionally (sets.midcast.bladeten)
 	end
 
 	if spell.english == "Blade: Jin" then
-		equip (sets.midcast.bladeten)
+		equipSetConditionally (sets.midcast.bladeten)
 	end
 
 	if spell.english == "Savage Blade" then
-		equip (sets.midcast.savageblade)
+		equipSetConditionally (sets.midcast.savageblade)
 	end
 
 	if spell.english == "Aeolian Edge" then
-		equip (sets.midcast.savageblade)
+		equipSetConditionally (sets.midcast.savageblade)
 	end
 
 	if spell.english == "Evisceration" then
-		equip (sets.midcast.evis)
+		equipSetConditionally (sets.midcast.evis)
 	end
 
 	if spell.english == "True Strike" then
-		equip (sets.midcast.truestrike)
+		equipSetConditionally (sets.midcast.truestrike)
 	end
 
 	if spell.english == "Asuran Fists" then
-		equip (sets.midcast.asuran)
+		equipSetConditionally (sets.midcast.asuran)
 	end
 
 	if spell.english == "Judgment" then
-		equip (sets.midcast.truestrike)
+		equipSetConditionally (sets.midcast.truestrike)
 	end
 
 	if spell.english == "Tachi: Ageha" then
-		equip (sets.midcast.enfnin)
+		equipSetConditionally (sets.midcast.enfnin)
 	end
 
 	if spell.english == "Tachi: Kasha" then
-		equip (sets.midcast.savageblade)
+		equipSetConditionally (sets.midcast.savageblade)
 	end
 
 	if spell.english == "Tachi: Koki" then
-		equip (sets.midcast.bladechi)
+		equipSetConditionally (sets.midcast.bladechi)
 	end
 
 	if spell.english == "Tachi: Jinpu" then
-		equip (sets.midcast.bladeten)
+		equipSetConditionally (sets.midcast.bladeten)
 	end
 
 	if spell.english == "Tachi: Kagero" then
-		equip (sets.midcast.bladechi)
+		equipSetConditionally (sets.midcast.bladechi)
 	end
 
 	if spell.english == "Tachi:Goten" then
-		equip (sets.midcast.bladeten)
+		equipSetConditionally (sets.midcast.bladeten)
 	end
 
 	if spell.type == "Trust" then
-		equip(sets.precast.fc)
+		equipSetConditionally(sets.precast.fc)
 	end
 end
 
@@ -843,11 +850,7 @@ end
 -- You can create tp_mode gearsets for ANY purpose.  Just make sure you label them correctly.  All must be in the sets.aftercast section.  For instance sets.aftercast.dw40.
 -- Don't forget to create a new gearset section defining the gear you want in it if you don't want to use my predefined sets.  Ie create a gearset for sets.aftercast.storetp.
 function aftercast(spell, act, spellMap, eventArgs)
-    set = sets.aftercast
-	if set[tp_mode] then
-		set = set[tp_mode]
-	end
-	equip(set)
+	equip_selected_set()
 	check_tool_count()
   --buff_change()
 	gearswap_jobbox:text(gearswap_box())


### PR DESCRIPTION
hey nextgames! thanks for all your ninja and endgame content.  thought i would try to pay you back some with some [perceived] improvements to your GS file.  i'm new to gearswap and just now going through your ninja video series, so forgive me if there were reasons beyond my understanding as per why it was done the way it was.  but i'm a software engineer by trade, so it's pretty easy for me to pick this up quickly and make some improvements to efficiency/framework - as long as I'm not missing something in my ignorance.  anyway, here's an explanation of the changes, corresponding to the commits:

1) Equip the selected gearset as soon as you run the tp mode command
   - I found the current set up to be unfortunate for 2 reasons
      a) You had to keep nearly identical copies of macro banks 
      b) You had to rely on an action actually being performed (i.e. provoke) for it to equip the gearset for the selected tp mode.  
          If the action's timer is not ready yet, then your gearset doesn't get equipped until performing **another** action.
   - With this change, you can consolidate all those near-copy banks down to a single one, and you can add tp mode setter 
      macros to your common bank to facilitate the changes between tp modes.
2) I added a layer to the precast/midcast equip process wherein it checks conditionally to make sure tp mode is not set to "hp".  If it is, then no dynamic gear changes will be performed.  This will allow you to continue using gearswap even for your high hp gearsets, without worrying about swapping.  That way you don't have to disable gearswap just for the sake of that particular gearset.

Feel free to ignore if it doesn't make sense for some reason unbeknownst to me or if it doesn't suit your style.  Just trying to pay it forward :-)